### PR TITLE
ProductType details with list of products in that category 

### DIFF
--- a/Bangazon/Controllers/ProductsController.cs
+++ b/Bangazon/Controllers/ProductsController.cs
@@ -9,6 +9,7 @@ using Bangazon.Data;
 using Bangazon.Models;
 using Microsoft.AspNetCore.Identity;
 using Bangazon.Models.ProductViewModels;
+using Microsoft.AspNetCore.Authorization;
 
 namespace Bangazon.Controllers
 {
@@ -44,6 +45,26 @@ namespace Bangazon.Controllers
                 }).ToListAsync();
             return View(model);
         }
+
+        //GET: ProductType details with a  list of all the products in that category.
+        [Authorize]
+        public async Task<IActionResult> ProductTypeDetails(int? id)
+        {
+            if (id == null)
+            {
+                return NotFound();
+            }
+            var productType = await _context.ProductType
+                    .Include(p => p.Products)
+                       .FirstOrDefaultAsync(p => p.ProductTypeId == id);
+
+            if(productType == null)
+            {
+                return NotFound();
+            }
+            return View(productType);
+        }
+
 
         // GET: Products/Details/5
         public async Task<IActionResult> Details(int? id)

--- a/Bangazon/Models/ProductType.cs
+++ b/Bangazon/Models/ProductType.cs
@@ -12,7 +12,7 @@ namespace Bangazon.Models
 
     [Required]
     [StringLength(255)]
-    [Display(Name="Category")]
+    
     public string Label { get; set; }
 
     [NotMapped]

--- a/Bangazon/Views/Products/Details.cshtml
+++ b/Bangazon/Views/Products/Details.cshtml
@@ -70,8 +70,9 @@
         <dt class = "col-sm-2">
             @Html.DisplayNameFor(model => model.ProductType)
         </dt>
-        <dd class = "col-sm-10">
+        <dd class="col-sm-10">
             @Html.DisplayFor(model => model.ProductType.Label)
+            <a asp-controller="Products" asp-action="ProductTypeDetails" asp-route-id="@Model.ProductTypeId">(Details)</a>
         </dd>
     </dl>
 </div>

--- a/Bangazon/Views/Products/Index.cshtml
+++ b/Bangazon/Views/Products/Index.cshtml
@@ -8,7 +8,7 @@
 {
     <h4>
         <div>
-            @Html.ActionLink(item.TypeName, "Details", "ProductTypes", new { id = item.TypeId }, null)
+            @Html.ActionLink(item.TypeName, "ProductTypeDetails", "Products", new { id = item.TypeId }, null)
             (@Html.DisplayFor(modelItem => item.ProductCount))
         </div>
     </h4>

--- a/Bangazon/Views/Products/ProductTypeDetails.cshtml
+++ b/Bangazon/Views/Products/ProductTypeDetails.cshtml
@@ -1,0 +1,54 @@
+﻿@model Bangazon.Models.ProductType
+
+@{
+    ViewData["Title"] = "ProductTypeDetails";
+}
+
+<h1>ProductTypeDetails</h1>
+
+<div>
+    <h4>ProductType</h4>
+    <hr />
+    
+           
+    
+</div>
+<table class="table">
+    <thead>
+        <tr>
+
+            <th>
+                Name
+            </th>
+            <th>
+                Quantity
+            </th>
+            <th>
+                Price
+            </th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+        @foreach (var item in Model.Products)
+        {
+            <tr>
+
+                <td>
+                    @Html.DisplayFor(Model => item.Title)
+                </td>
+                <td>
+                    @Html.DisplayFor(Model => item.Quantity)
+                </td>
+                <td>
+                    @Html.DisplayFor(Model => item.Price)
+                </td>
+                
+            </tr>
+        }
+    </tbody>
+</table>
+<div>
+    <a asp-action="Edit" asp-route-id="@Model.ProductTypeId">Edit</a> |
+    <a asp-action="Index">Back to List</a>
+</div>

--- a/Bangazon/Views/Products/ProductTypeDetails.cshtml
+++ b/Bangazon/Views/Products/ProductTypeDetails.cshtml
@@ -7,9 +7,10 @@
 <h1>ProductTypeDetails</h1>
 
 <div>
-    <h4>ProductType</h4>
+    <h3>ProductType</h3>
     <hr />
     
+    <h4>@Html.DisplayFor(modelItem => Model.Label)</h4>
            
     
 </div>


### PR DESCRIPTION
Details for ProductTypes lists the Category name and each product in the category with Title quantity and price per unity.





Fixes Issue # https://github.com/fancy-explosions/BangazonSite/issues/3

## Type of change

Please delete options that are not relevant.


- [ x] New feature (non-breaking change which adds functionality)


# Testing Instructions

Git fetch --all
git checkout cm-ProductType-Details
On the index page for products each category should be a link to its details page
If you click on an actual product the Producttype on that details page should also have a link to 
the product type details for that category.



# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added test instructions that prove my fix is effective or that my feature works
