### PR TITLE
The user cannot post an item for less than 0.01 or greater than 10000

### DIFF
--- a/Bangazon/Models/Product.cs
+++ b/Bangazon/Models/Product.cs
@@ -27,6 +27,7 @@ namespace Bangazon.Models
         public string Title { get; set; }
 
         [Required]
+        [Range(0.01, 10000)]
         [DisplayFormat(DataFormatString = "{0:C}")]
         public double Price { get; set; }
 


### PR DESCRIPTION
# Description
Added code to check that the user has entered a that is no less than 0.01 or greater than 10000

Fixes Issue # (link issue ticket here)
#13

## Type of change

Please delete options that are not relevant.


- [x] New feature (non-breaking change which adds functionality)

# Testing Instructions

Please describe the tests required to verify your changes. Provide instructions so PR Tester can check functionality. Please also list any relevant details for your tests

git fetch --all
git checkout my-issue-13
select `Sell Something` at the top
create a new product to sell and enter both 0 or 10,000.01 into the price field
if the user enters either value they should be prompted a message that the price of the product is invalid

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added test instructions that prove my fix is effective or that my feature works
